### PR TITLE
Should work with newer versions of php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "route4me/route4me-php",
+  "name": "ytauber/route4me-php",
   "description": "Access Route4Me's logistics-as-a-service API using our PHP SDK",
   "minimum-stability": "stable",
   "version": "1.2.2",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "ytauber/route4me-php",
+  "name": "route4me/route4me-php",
   "description": "Access Route4Me's logistics-as-a-service API using our PHP SDK",
   "minimum-stability": "stable",
   "version": "1.2.2",

--- a/src/Route4Me/OptimizationProblem.php
+++ b/src/Route4Me/OptimizationProblem.php
@@ -198,23 +198,23 @@ class OptimizationProblem extends Common
         $allQueryFields = ['optimization_problem_id', 'reoptimize'];
         $allBodyFields = ['addresses', 'parameters'];
 
-        $query = is_array($params)
-                    ? (isset($params['optimization_problem_id']) || isset($params['parameters']))
-                        ? Route4Me::generateRequestParameters($allQueryFields, $params)
-                        : null
-                    : (isset($params->optimization_problem_id) || isset($params->parameters))
-                        ? Route4Me::generateRequestParameters($allQueryFields, $params)
-                        : null;
+       $query = is_array($params)
+            ? ((isset($params['optimization_problem_id']) || isset($params['parameters']))
+                ? Route4Me::generateRequestParameters($allQueryFields, $params)
+                : null)
+            : ((isset($params->optimization_problem_id) || isset($params->parameters))
+                ? Route4Me::generateRequestParameters($allQueryFields, $params)
+                : null);
 
         $body = is_array($params)
-            ? (isset($params['addresses']) && sizeof($params['addresses'])>0) ||
-            (isset($params['parameters']) && sizeof($params['parameters'])>0)
+            ? ((isset($params['addresses']) && sizeof($params['addresses']) > 0) ||
+                (isset($params['parameters']) && sizeof($params['parameters']) > 0)
                 ? Route4Me::generateRequestParameters($allBodyFields, $params)
-                : null
-            : (isset($params->addresses) && sizeof($params->addresses)>0) ||
-                (isset($params->parameters) && sizeof($params->parameters)>0)
-                    ? Route4Me::generateRequestParameters($allBodyFields, $params)
-                    : null;
+                : null)
+            : ((isset($params->addresses) && sizeof($params->addresses) > 0) ||
+                (isset($params->parameters) && sizeof($params->parameters) > 0)
+                ? Route4Me::generateRequestParameters($allBodyFields, $params)
+                : null);
 
         $optimize = Route4Me::makeRequst([
             'url'       => Endpoint::OPTIMIZATION_PROBLEM,


### PR DESCRIPTION
Was getting this error


Unparenthesized `a ? b : c ? d : e` is deprecated. Use either `(a ? b : c) ? d : e` or `a ? b : (c ? d : e)`
 at vendor/route4me/route4me-php/src/Route4Me/OptimizationProblem.php:221