### PR TITLE
feat: add bulk deleteRouteDestinations to Address

### DIFF
--- a/src/Route4Me/Address.php
+++ b/src/Route4Me/Address.php
@@ -211,6 +211,22 @@ class Address extends Common
         return $result;
     }
 
+    public function deleteRouteDestinations(array $routeDestinationIds)
+    {
+        $result = Route4Me::makeRequst([
+            'url'           => Endpoint::DELETE_ROUTE_DESTINATION,
+            'method'        => 'POST',
+            'query'         => ['format' => 'json'],
+            'body'          => [
+                'route_destination_ids' => implode(',', $routeDestinationIds),
+            ],
+            'HTTPHEADER'    => 'Content-Type: multipart/form-data',
+            'HTTPHEADERS'   => ['Accept: application/json'],
+        ]);
+
+        return $result;
+    }
+
     public function getAddressId()
     {
         return $this->route_destination_id;

--- a/src/Route4Me/Enum/Endpoint.php
+++ b/src/Route4Me/Enum/Endpoint.php
@@ -15,6 +15,7 @@ class Endpoint
 
     const ADDRESS_V4 = '/api.v4/address.php';
     const MOVE_ROUTE_DESTINATION = '/actions/route/move_route_destination.php';
+    const DELETE_ROUTE_DESTINATION = '/actions/route/delete_route_destination.php';
     const MARK_ADDRESS_DEPARTED = '/api/route/mark_address_departed.php';
     const UPDATE_ADDRESS_VISITED = '/actions/address/update_address_visited.php';
 


### PR DESCRIPTION
## Summary
- Add `Address::deleteRouteDestinations(array $ids)` to remove multiple route destinations in one call via `POST /actions/route/delete_route_destination.php`.
- Sends `route_destination_ids` as a comma-joined list, with `format=json` and `Accept: application/json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)