### PR TITLE
fix: prevent base URL leaking across SDK requests

### DIFF
--- a/UnitTestFiles/Test/BaseUrlLeakUnitTests.php
+++ b/UnitTestFiles/Test/BaseUrlLeakUnitTests.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace UnitTestFiles\Test;
+
+use Route4Me\Enum\Endpoint;
+use Route4Me\Route4Me;
+
+/**
+ * Regression tests for the stateful base-URL poisoning bug: entrypoints that
+ * talk to a non-default host must not leave the shared Route4Me::$baseUrl
+ * pointing at that host, or a later request (e.g. AddAddressNote) leaks to it.
+ */
+class BaseUrlLeakUnitTests extends \PHPUnit\Framework\TestCase
+{
+    protected function setUp()
+    {
+        // Start every case from the known-good default host.
+        Route4Me::setBaseUrl(Endpoint::BASE_URL);
+    }
+
+    protected function tearDown()
+    {
+        Route4Me::setBaseUrl(Endpoint::BASE_URL);
+    }
+
+    public function testVehicleConstructorsDoNotPoisonBaseUrl()
+    {
+        new \Route4Me\Vehicles\VehicleV4();
+        new \Route4Me\Vehicles\Vehicle();
+        new \Route4Me\Vehicles\VehiclesResponseV4();
+
+        $this->assertEquals(
+            Endpoint::BASE_URL,
+            Route4Me::getBaseUrl(),
+            'WH vehicle classes must not mutate the shared base URL'
+        );
+    }
+
+    /**
+     * Telematics vendor discovery is the reported poison source. It must route
+     * itself per-request and leave the global default intact for later note
+     * traffic. Assertion is stable regardless of whether the HTTP call succeeds.
+     */
+    public function testTelematicsDiscoveryDoesNotPoisonBaseUrl()
+    {
+        try {
+            \Route4Me\TelematicsGateway\TelematicsVendor::GetTelematicsVendors(null);
+        } catch (\Exception $e) {
+            // Network/API outcome is irrelevant; we only assert the side effect.
+        }
+
+        $this->assertEquals(
+            Endpoint::BASE_URL,
+            Route4Me::getBaseUrl(),
+            'GetTelematicsVendors must not leave the base URL on the telematics host'
+        );
+    }
+
+    public function testPerRequestBaseUrlOverrideDoesNotMutateGlobal()
+    {
+        // makeRequst may fail on the fake host; the point is the global is untouched.
+        try {
+            Route4Me::makeRequst([
+                'baseUrl' => 'https://example.invalid',
+                'url'     => '/nowhere',
+                'method'  => 'GET',
+            ]);
+        } catch (\Exception $e) {
+        }
+
+        $this->assertEquals(
+            Endpoint::BASE_URL,
+            Route4Me::getBaseUrl(),
+            'A per-request baseUrl override must not change the shared default'
+        );
+    }
+}

--- a/src/Route4Me/Geocoding.php
+++ b/src/Route4Me/Geocoding.php
@@ -44,8 +44,6 @@ class Geocoding extends Common
 
     public static function getStreetData($params)
     {
-        Route4Me::setBaseUrl(Endpoint::STREET_DATA);
-
         $allPathFields = ['pk', 'offset', 'limit'];
 
         $url_query = Route4Me::generateUrlPath($allPathFields, $params);
@@ -53,6 +51,7 @@ class Geocoding extends Common
         $query = [];
 
         $response = Route4Me::makeRequst([
+            'baseUrl'   => Endpoint::STREET_DATA,
             'url'       => $url_query,
             'method'    => 'GET',
             'query'     => $query,
@@ -63,8 +62,6 @@ class Geocoding extends Common
 
     public static function getZipCode($params)
     {
-        Route4Me::setBaseUrl(Endpoint::STREET_DATA_ZIPCODE);
-
         $allPathFields = ['zipcode', 'offset', 'limit'];
 
         $url_query = Route4Me::generateUrlPath($allPathFields, $params);
@@ -72,6 +69,7 @@ class Geocoding extends Common
         $query = [];
 
         $response = Route4Me::makeRequst([
+            'baseUrl'   => Endpoint::STREET_DATA_ZIPCODE,
             'url'       => $url_query,
             'method'    => 'GET',
             'query'     => $query,
@@ -82,8 +80,6 @@ class Geocoding extends Common
 
     public static function getService($params)
     {
-        Route4Me::setBaseUrl(Endpoint::STREET_DATA_SERVICE);
-
         $allPathFields = ['zipcode', 'housenumber', 'offset', 'limit'];
 
         $url_query = Route4Me::generateUrlPath($allPathFields, $params);
@@ -91,6 +87,7 @@ class Geocoding extends Common
         $query = [];
 
         $response = Route4Me::makeRequst([
+            'baseUrl'   => Endpoint::STREET_DATA_SERVICE,
             'url'       => $url_query,
             'method'    => 'GET',
             'query'     => $query,

--- a/src/Route4Me/Route4Me.php
+++ b/src/Route4Me/Route4Me.php
@@ -84,7 +84,10 @@ class Route4Me
                 ['api_key' => self::getApiKey()]
             )) : '';
 
-        $baseUrl = self::getBaseUrl();
+        // Per-request host override; falls back to the global default so existing
+        // setBaseUrl() callers are unaffected. Prevents one call's host from leaking
+        // into a later unrelated request.
+        $baseUrl = isset($options['baseUrl']) ? $options['baseUrl'] : self::getBaseUrl();
 
         $curlOpts = [
             CURLOPT_URL             => $baseUrl.$url,

--- a/src/Route4Me/TelematicsGateway/TelematicsVendor.php
+++ b/src/Route4Me/TelematicsGateway/TelematicsVendor.php
@@ -86,11 +86,10 @@ class TelematicsVendor extends Common
      */
     public static function GetTelematicsVendors($params)
     {
-        Route4Me::setBaseUrl(Endpoint::TELEMATICS_VENDORS);
-
         $allQueryFields = ['vendor_id', 'is_integrated', 'page', 'per_page', 'country', 'feature', 'search', 'vendors'];
 
         $vendors = Route4Me::makeRequst([
+            'baseUrl'   => Endpoint::TELEMATICS_VENDORS,
             'url'       => '',
             'method'    => 'GET',
             'query'     => Route4Me::generateRequestParameters($allQueryFields, $params),

--- a/src/Route4Me/TelematicsVendor.php
+++ b/src/Route4Me/TelematicsVendor.php
@@ -24,11 +24,10 @@ class TelematicsVendor extends Common
 
     public static function GetTelematicsVendors($params)
     {
-        Route4Me::setBaseUrl(Endpoint::TELEMATICS_VENDORS);
-
         $allQueryFields = ['vendor_id', 'is_integrated', 'page', 'per_page', 'country', 'feature', 'search', 'vendors'];
 
         $vendors = Route4Me::makeRequst([
+            'baseUrl'   => Endpoint::TELEMATICS_VENDORS,
             'url'       => '',
             'method'    => 'GET',
             'query'     => Route4Me::generateRequestParameters($allQueryFields, $params),

--- a/src/Route4Me/Vehicles/Vehicle.php
+++ b/src/Route4Me/Vehicles/Vehicle.php
@@ -78,7 +78,6 @@ class Vehicle extends \Route4Me\Common
 
     public function __construct()
     {
-        Route4Me::setBaseUrl(Endpoint::WH_BASE_URL);
     }
 
     public static function fromArray(array $params)
@@ -106,6 +105,7 @@ class Vehicle extends \Route4Me\Common
         $allQueryFields = ['with_pagination', 'page', 'perPage'];
 
         $response = Route4Me::makeRequst([
+            'baseUrl' => Endpoint::WH_BASE_URL,
             'url' => Endpoint::VEHICLE_V4,
             'method' => 'GET',
             'query' => Route4Me::generateRequestParameters($allQueryFields, $params),
@@ -140,6 +140,7 @@ class Vehicle extends \Route4Me\Common
     public function getVehicleByID($vehicleID)
     {
         $response = Route4Me::makeRequst([
+            'baseUrl' => Endpoint::WH_BASE_URL,
             'url' => Endpoint::VEHICLE_V4 . '/' . $vehicleID,
             'method' => 'GET',
         ]);
@@ -158,6 +159,7 @@ class Vehicle extends \Route4Me\Common
         $allBodyFields = Route4Me::getObjectProperties(new self(), ['vehicle_id']);
 
         $response = Route4Me::makeRequst([
+            'baseUrl' => Endpoint::WH_BASE_URL,
             'url' => Endpoint::VEHICLE_V4 . '/' . $vehicleID,
             'method' => 'PUT',
             'body' => Route4Me::generateRequestParameters($allBodyFields, $params),
@@ -176,9 +178,8 @@ class Vehicle extends \Route4Me\Common
         $excludeFields = ['vehicle_id', 'is_deleted', 'created_time', 'timestamp_added', 'timestamp_removed'];
         $allBodyFields = Route4Me::getObjectProperties(new self(), $excludeFields);
 
-        Route4Me::setBaseUrl(Endpoint::BASE_URL);
-
         $response = Route4Me::makeRequst([
+            'baseUrl' => Endpoint::BASE_URL,
             'url' => Endpoint::VEHICLE_V4_API,
             'method' => 'POST',
             'body' => Route4Me::generateRequestParameters($allBodyFields, $params),
@@ -197,6 +198,7 @@ class Vehicle extends \Route4Me\Common
         $vehicleID = isset($params->vehicle_id) ? $params->vehicle_id : null;
 
         $response = Route4Me::makeRequst([
+            'baseUrl' => Endpoint::WH_BASE_URL,
             'url' => Endpoint::VEHICLE_V4 . '/' . $vehicleID,
             'method' => 'DELETE',
             'HTTPHEADER' => 'Content-Type: application/json',

--- a/src/Route4Me/Vehicles/VehicleV4.php
+++ b/src/Route4Me/Vehicles/VehicleV4.php
@@ -184,7 +184,6 @@ class VehicleV4 extends \Route4Me\Common
 
     public function __construct()
     {
-        Route4Me::setBaseUrl(Endpoint::WH_BASE_URL);
     }
 
     public static function fromArray(array $params)
@@ -212,6 +211,7 @@ class VehicleV4 extends \Route4Me\Common
         $allQueryFields = ['with_pagination', 'page', 'perPage'];
 
         $response = Route4Me::makeRequst([
+            'baseUrl' => Endpoint::WH_BASE_URL,
             'url' => Endpoint::VEHICLE_V4,
             'method' => 'GET',
             'query' => Route4Me::generateRequestParameters($allQueryFields, $params),
@@ -227,6 +227,7 @@ class VehicleV4 extends \Route4Me\Common
     public function getVehicleByID($vehicleID)
     {
         $response = Route4Me::makeRequst([
+            'baseUrl' => Endpoint::WH_BASE_URL,
             'url' => Endpoint::VEHICLE_V4.'/'.$vehicleID,
             'method' => 'GET',
         ]);
@@ -245,6 +246,7 @@ class VehicleV4 extends \Route4Me\Common
         $allBodyFields = Route4Me::getObjectProperties(new self(), ['vehicle_id']);
 
         $response = Route4Me::makeRequst([
+            'baseUrl' => Endpoint::WH_BASE_URL,
             'url' => Endpoint::VEHICLE_V4.'/'.$vehicleID,
             'method' => 'PUT',
             'body' => Route4Me::generateRequestParameters($allBodyFields, $params),
@@ -263,9 +265,8 @@ class VehicleV4 extends \Route4Me\Common
         $excludeFields = ['vehicle_id','is_deleted','created_time','timestamp_added','timestamp_removed'];
         $allBodyFields = Route4Me::getObjectProperties(new self(), $excludeFields);
 
-        //Route4Me::setBaseUrl(Endpoint::BASE_URL);
-
         $response = Route4Me::makeRequst([
+            'baseUrl' => Endpoint::WH_BASE_URL,
             'url' => Endpoint::VEHICLE_V4,
             'method' => 'POST',
             'body' => Route4Me::generateRequestParameters($allBodyFields, $params),
@@ -284,6 +285,7 @@ class VehicleV4 extends \Route4Me\Common
         $vehicleID = isset($params->vehicle_id) ? $params->vehicle_id : null;
 
         $response = Route4Me::makeRequst([
+            'baseUrl' => Endpoint::WH_BASE_URL,
             'url' => Endpoint::VEHICLE_V4.'/'.$vehicleID,
             'method' => 'DELETE',
             'HTTPHEADER' => 'Content-Type: application/json',

--- a/src/Route4Me/Vehicles/VehiclesResponseV4.php
+++ b/src/Route4Me/Vehicles/VehiclesResponseV4.php
@@ -75,7 +75,6 @@ class VehiclesResponseV4 extends \Route4Me\Common
 
     public function __construct()
     {
-        Route4Me::setBaseUrl(Endpoint::WH_BASE_URL);
     }
 
     public static function fromArray(array $params)


### PR DESCRIPTION
## Problem

`Route4Me::$baseUrl` is a mutable process-wide static, and `makeRequst()` builds every request as `getBaseUrl() . $url`. A few methods point it at a non-default host and never restore it, so any later request whose caller doesn't set its own host inherits the stale one.

Reported impact: after `TelematicsVendor::GetTelematicsVendors()`, a subsequent `AddressNote::AddAddressNote()` / `AddNoteFile()` in the same runtime was sent to `http://telematics.route4me.com/...` — leaking the API key, the note body, and (for file notes) the uploaded file bytes.

## Fix

- `makeRequst()` gains a **non-mutating per-request `baseUrl` override**; it defaults to `self::getBaseUrl()`, so existing callers are unaffected.
- Every source that used to clobber the shared global now passes its host per-request instead:
  - `TelematicsVendor::GetTelematicsVendors()` (both the `Route4Me\` and `Route4Me\TelematicsGateway\` copies)
  - `Geocoding` street-data: `getStreetData`, `getZipCode`, `getService`
  - WH vehicles `VehicleV4` / `Vehicle` — host moved out of the constructors into each request; `VehiclesResponseV4` constructor mutation dropped
- Adds a regression test that fails if a poison source ever leaves the global on a non-default host again.

## Scope / notes

- **The reported vulnerability is fully resolved by this diff.** V5's `setBaseUrl('')` is the same *pattern* but not a leak — an empty base yields a broken relative request, not exfiltration to a foreign host. Left as follow-up cleanup, not a residual security hole.
- `Endpoint::TELEMATICS_VENDORS` is `http://`; note traffic is now back on `https://api.route4me.com` regardless. Hardening that endpoint to HTTPS is separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)